### PR TITLE
change default size of az

### DIFF
--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -94,7 +94,7 @@ func constructClusterConf(rawConf *pb.ClusterRawConf) (clusterConf *pb.ClusterCo
 		region = rawConf.Region
 	}
 
-	numOfAz := 3
+	numOfAz := 1
 	if rawConf != nil && rawConf.NumOfAz != 0 {
 		numOfAz = int(rawConf.NumOfAz)
 


### PR DESCRIPTION
user node 의 default ax size 를 1 로 변경합니다.

@robertchoi80 
이것만 변경하면 user node 는 기본적으로 1개만 설치될 것으로 기대하는데요. 혹시 추가로 변경해야 하는 사항이 있다면 코멘트 바랍니다.
